### PR TITLE
feat: add caching to latest message

### DIFF
--- a/app/javascript/src/components/messages/Index.vue
+++ b/app/javascript/src/components/messages/Index.vue
@@ -49,7 +49,7 @@ export default defineComponent({
     );
 
     const { data: messages } = useSWRV<Message[]>(
-      () => channelId.value && `/ajax/channels/${channelId.value}/messages`,
+      "/ajax/message_lists",
       gateway.get
     );
 

--- a/app/services/message_lists/index_service.rb
+++ b/app/services/message_lists/index_service.rb
@@ -4,7 +4,7 @@ module MessageLists
   # Messages IndexService
   class IndexService
     def execute
-      Message.latest_messages.with_includes
+      Messages::LatestMessageService.new(Message.with_includes).execute
     end
   end
 end

--- a/app/services/messages/latest_message_service.rb
+++ b/app/services/messages/latest_message_service.rb
@@ -1,0 +1,31 @@
+module Messages
+  class LatestMessageService
+    # @param message_relation[Message::ActiveRecordRelation]
+    def initialize(message_relation)
+      @message_relation = message_relation
+    end
+
+    def execute
+      latest_message_ids = Rails.cache.read(cache_key)
+
+      if latest_message_ids.present?
+        message_relation.where(id: latest_message_ids)
+      else
+        Rails.cache.write(cache_key, Message.latest_messages.ids)
+        message_relation.latest_messages
+      end
+    end
+
+    def last_updated_at
+      @last_updated_at ||= Message.pick('MAX(updated_at)')
+    end
+
+    def cache_key
+      "latest_message_ids:#{last_updated_at}"
+    end
+
+    private
+
+    attr_reader :message_relation
+  end
+end

--- a/db/Schemafile
+++ b/db/Schemafile
@@ -19,6 +19,7 @@ create_table 'messages', force: :cascade do |t|
   t.bigint   'created_by',               null: false
   t.datetime 'created_at', precision: 6, null: false
   t.datetime 'updated_at', precision: 6, null: false
+  add_index 'messages', ["updated_at"],       name: "index_messages_on_updated_at",  using: :btree
   add_index 'messages', ["id", "created_by"], name: "fk_messages_on_users", unique: true, using: :btree
   add_index 'messages', ["id", "channel_id"], name: "fk_messages_on_channels", unique: true, using: :btree
 end


### PR DESCRIPTION
## Without Cache Hit
**747.6ms in ActiveRecord**
```
Started GET "/ajax/message_lists" for 127.0.0.1 at 2022-09-01 01:25:02 +0900
[Tracing] Starting <rails.request> transaction </ajax/message_lists>
Processing by Ajax::MessageListsController#index as HTML
   (25.4ms)  SELECT MAX(updated_at) FROM `messages` LIMIT 1
  ↳ app/services/messages/latest_message_service.rb:20:in `last_updated_at'
   (370.3ms)  SELECT `messages`.`id` FROM `messages` WHERE (NOT EXISTS (
    select
      1
    from
      messages msg2
    where
      messages.channel_id = msg2.channel_id
      and messages.created_at < msg2.created_at
  ))
  ↳ app/services/messages/latest_message_service.rb:14:in `execute'
  Message Load (345.4ms)  SELECT `messages`.* FROM `messages` WHERE (NOT EXISTS (
    select
      1
    from
      messages msg2
    where
      messages.channel_id = msg2.channel_id
      and messages.created_at < msg2.created_at
  ))
  ↳ app/usecases/ajax/message_lists/index_usecase.rb:9:in `call'
  User Load (3.6ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` IN (2, 32, 39, 17, 19, 97, 20, 21, 29, 33, 8, 98, 59, 54, 30, 106, 63, 51, 50, 24, 72, 70, 60, 79, 84, 89, 46, 40, 3, 80, 28, 105, 44, 85, 103, 101, 35, 94, 69, 99, 68, 5, 9, 90, 107, 92, 37, 100, 42, 43, 75, 31, 38, 47, 56, 49, 52, 76, 61, 91, 73, 78, 93, 77, 83, 81, 58, 1, 53)
  ↳ app/usecases/ajax/message_lists/index_usecase.rb:9:in `call'
  Channel Load (2.9ms)  SELECT `channels`.* FROM `channels` WHERE `channels`.`id` IN (55, 37, 52, 29, 87, 51, 19, 61, 99, 41, 97, 60, 2, 20, 13, 96, 93, 95, 80, 89, 4, 71, 65, 11, 25, 9, 54, 90, 59, 104, 32, 12, 22, 44, 17, 64, 6, 101, 8, 102, 18, 81, 98, 88, 21, 70, 24, 66, 67, 5, 27, 10, 28, 82, 16, 84, 42, 33, 57, 58, 56, 77, 46, 48, 85, 91, 74, 34, 14, 83, 50, 75, 68, 1, 76, 79, 35, 43, 62, 72, 36, 31, 40, 30, 94, 15, 39, 63, 69, 86, 53, 26, 92, 103, 47, 45, 3, 23, 38, 100, 7, 78, 49, 73)
  ↳ app/usecases/ajax/message_lists/index_usecase.rb:9:in `call'
Completed 200 OK in 785ms (Views: 6.0ms | ActiveRecord: 747.6ms | Allocations: 28072)
```


## With Cache Hit
**35.5ms in ActiveRecord** 
```
Started GET "/ajax/message_lists" for 127.0.0.1 at 2022-09-01 01:23:39 +0900
[Tracing] Starting <rails.request> transaction </ajax/message_lists>
Processing by Ajax::MessageListsController#index as HTML
   (21.1ms)  SELECT MAX(updated_at) FROM `messages` LIMIT 1
  ↳ app/services/messages/latest_message_service.rb:20:in `last_updated_at'
  Message Load (6.4ms)  SELECT `messages`.* FROM `messages` WHERE `messages`.`id` IN (53990, 54115, 54040, 54113, 54096, 54039, 54050, 54035, 54032, 54095, 53858, 54059, 53808, 54002, 54053, 54076, 54024, 54041, 54077, 54104, 54090, 53622, 54025, 54061, 54109, 54008, 53772, 53965, 53979, 54058, 54043, 54044, 53881, 53937, 53996, 54005, 54029, 54099, 53913, 54089, 54045, 54092, 54101, 54070, 54078, 53814,
54073, 54068, 54081, 53994, 53721, 53991, 54051, 54060, 54114, 54054, 54016, 54091, 54106, 54082, 54105, 54000, 54034, 54080, 54015, 54052, 54063, 54049, 54093, 54072, 53978, 54111, 53957, 54028, 54112, 54074, 54042, 54107, 54066, 53923, 53969, 53849, 54094, 53995, 54084, 53553, 54004, 54088, 54108, 54001, 54009, 54110, 54103, 54100, 53984, 54102, 54037, 54079, 53898, 54087, 54098, 54010, 54097, 53963)
  ↳ app/usecases/ajax/message_lists/index_usecase.rb:9:in `call'
  User Load (4.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`id` IN (78, 50, 19, 79, 69, 61, 33, 3, 44, 103, 59, 80, 56, 53, 84, 76, 37, 89, 2, 5, 68, 91, 28, 100, 21, 93, 105, 60, 81, 35, 54, 24, 49, 51, 20, 39, 30, 52, 46, 40, 31, 97, 9, 43, 98, 107, 8, 72, 75, 106, 99, 85, 58, 42, 73, 1, 77, 101, 38, 29, 32, 17, 94, 90, 63, 92, 83, 70, 47)
  ↳ app/usecases/ajax/message_lists/index_usecase.rb:9:in `call'
  Channel Load (3.9ms)  SELECT `channels`.* FROM `channels` WHERE `channels`.`id` IN (15, 71, 27, 54, 2, 70, 31, 97, 22, 38, 8, 72, 44, 68, 73, 90, 36, 50, 59, 47, 55, 10, 5, 30, 17, 77, 86, 20, 39, 64, 9, 53, 78, 85, 42, 93, 65, 1, 6, 99, 46, 61, 3, 51, 52, 95, 35, 32, 12, 18, 34, 19, 28, 91, 13, 84, 104, 60, 82, 11, 74, 62, 66, 88, 83, 24, 79, 96, 80, 21, 23, 48, 67, 58, 94, 100, 63, 102, 4, 33, 81, 14,
 40, 41, 87, 49, 7, 101, 103, 98, 45, 92, 89, 56, 57, 43, 69, 25, 26, 75, 76, 29, 16, 37)
  ↳ app/usecases/ajax/message_lists/index_usecase.rb:9:in `call'
Completed 200 OK in 84ms (Views: 5.6ms | ActiveRecord: 35.5ms | Allocations: 27007)
```



